### PR TITLE
[Feat] S3 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.661'
 	compileOnly 'org.projectlombok:lombok'
 	implementation 'org.json:json:20231013'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/chrkb1569/CharacterName/config/S3Config.java
+++ b/src/main/java/com/chrkb1569/CharacterName/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.chrkb1569.CharacterName.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/chrkb1569/CharacterName/controller/CharacterNameController.java
+++ b/src/main/java/com/chrkb1569/CharacterName/controller/CharacterNameController.java
@@ -1,0 +1,22 @@
+package com.chrkb1569.CharacterName.controller;
+
+import com.chrkb1569.CharacterName.service.CharacterNameService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class CharacterNameController {
+    private final CharacterNameService characterNameService;
+
+    @GetMapping("/characterNames")
+    @ResponseStatus(HttpStatus.OK)
+    public void getCharacterNames() {
+        characterNameService.getCharacterNamesByAPI();
+    }
+}

--- a/src/main/java/com/chrkb1569/CharacterName/service/CharacterNameService.java
+++ b/src/main/java/com/chrkb1569/CharacterName/service/CharacterNameService.java
@@ -1,0 +1,36 @@
+package com.chrkb1569.CharacterName.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CharacterNameService {
+    private final S3Service s3Service;
+    private final ParseService parseService;
+    private static int INITIAL_PAGE = 1;
+    private static final int MAXIMUM_LIST_SIZE = 200;
+
+    @Value("${api.file.name}")
+    private String BASIC_FILE_NAME;
+
+    public void getCharacterNamesByAPI() {
+        while(true) {
+            String fileName = BASIC_FILE_NAME + INITIAL_PAGE;
+            List<String> characterNames = parseService.getCharacterNames(INITIAL_PAGE++);
+
+            s3Service.saveCharacterNames(fileName, characterNames);
+
+            if(characterNames.size() != MAXIMUM_LIST_SIZE) break;
+
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/chrkb1569/CharacterName/service/S3Service.java
+++ b/src/main/java/com/chrkb1569/CharacterName/service/S3Service.java
@@ -1,0 +1,38 @@
+package com.chrkb1569.CharacterName.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.bucketName}")
+    private String bucketName;
+
+    private final static String TEXT_FILE_EXTENSION = ".txt";
+
+    public void saveCharacterNames(String fileName, List<String> characterNames) {
+        String addedExtension = addExtension(fileName);
+
+        byte[] byteArr = String.join(", ", characterNames).getBytes(StandardCharsets.UTF_8);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType("text/plain; charset=utf-8");
+        metadata.setContentEncoding("UTF-8");
+
+        amazonS3Client.putObject(bucketName, addedExtension, new ByteArrayInputStream(byteArr), metadata);
+    }
+
+    private String addExtension(String fileName) {
+        return fileName + TEXT_FILE_EXTENSION;
+    }
+}


### PR DESCRIPTION
- AWS S3 로직 추가
    - API를 통하여 파싱한 정보를 txt 파일로 변환한 뒤, 이를 AWS S3에 저장하도록 구현
    - 현재 데이터 요청을 통하여 생성되는 파일의 개수 642개 -> 총 데이터 대략 12만 개 추정
    - 데이터 요청에 소요되는 시간 대략 12분


- 데이터 요청 소요 시간
<img width="816" alt="스크린샷 2024-02-20 오전 12 32 13" src="https://github.com/YoutStat/CharacterName_API/assets/89513086/f815c1b9-5556-4c3f-91eb-9280df6657c0">


- AWS S3
<img width="1336" alt="스크린샷 2024-02-20 오전 12 30 35" src="https://github.com/YoutStat/CharacterName_API/assets/89513086/51d49f28-d847-4d57-baa9-140af99fd16b">

